### PR TITLE
update to gleam 0.31

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: erlef/setup-beam@v1.15.2
         with:
           otp-version: "25.2"
-          gleam-version: "0.27.0"
+          gleam-version: "0.31.0"
           rebar3-version: "3"
           elixir-version: "1.14.2"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1.15.2
         with:
           otp-version: "25.2"
-          gleam-version: "0.27.0"
+          gleam-version: "0.31.0"
           rebar3-version: "3"
           elixir-version: "1.14.2"
       - run: gleam format --check src test
@@ -29,7 +29,7 @@ jobs:
       - uses: erlef/setup-beam@v1.15.2
         with:
           otp-version: "25.2"
-          gleam-version: "0.27.0"
+          gleam-version: "0.31.0"
           rebar3-version: "3"
           elixir-version: "1.14.2"
 
@@ -52,7 +52,7 @@ jobs:
       - uses: erlef/setup-beam@v1.15.2
         with:
           otp-version: "25.2"
-          gleam-version: "0.27.0"
+          gleam-version: "0.31.0"
           rebar3-version: "3"
           elixir-version: "1.14.2"
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -6,7 +6,7 @@ repository = { type = "github", user = "lunarmagpie", repo = "gloml" }
 links = [{ title = "Website", href = "https://github.com/lunarmagpie.gloml" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.27"
+gleam_stdlib = "~> 0.31"
 toml = "~> 0.7"
 
 [dev-dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.27.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "9DBDD21B48C654182CDD8AA15ACF85E8E74A0438583C68BD7EF08BE89F999C6F" },
-  { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
+  { name = "gleam_stdlib", version = "0.31.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "6D1BC5B4D4179B9FEE866B1E69FE180AC2CE485AD90047C0B32B2CA984052736" },
+  { name = "gleeunit", version = "0.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "1397E5C4AC4108769EE979939AC39BF7870659C5AFB714630DEEEE16B8272AD5" },
   { name = "toml", version = "0.7.0", build_tools = ["mix"], requirements = [], otp_app = "toml", source = "hex", outer_checksum = "0690246A2478C1DEFD100B0C9B89B4EA280A22BE9A7B313A8A058A2408A2FA70" },
 ]
 
 [requirements]
-gleam_stdlib = "~> 0.27"
-gleeunit = "~> 0.10"
-toml = "~> 0.7"
+gleam_stdlib = { version = "~> 0.31" }
+gleeunit = { version = "~> 0.10" }
+toml = { version = "~> 0.7" }

--- a/src/gloml.gleam
+++ b/src/gloml.gleam
@@ -47,31 +47,31 @@ pub fn decode_dynamic(toml_string: String) {
   decode_inner(toml_string)
 }
 
-if erlang {
-  external type ElxInvalidTomlError
+@target(erlang)
+type ElxInvalidTomlError
 
-  external fn decode_ex(
-    toml_string: String,
-  ) -> Result(dyn.Dynamic, ElxInvalidTomlError) =
-    "Elixir.Toml" "decode"
+@target(erlang)
+@external(erlang, "Elixir.Toml", "decode")
+fn decode_ex(toml_string: String) -> Result(dyn.Dynamic, ElxInvalidTomlError)
 
-  external fn get_reason(err: ElxInvalidTomlError) -> String =
-    "Elixir.TomlFFI" "get_reason"
+@target(erlang)
+@external(erlang, "Elixir.TomlFFI", "get_reason")
+fn get_reason(err: ElxInvalidTomlError) -> String
 
-  fn decode_inner(toml_string: String) -> Result(dyn.Dynamic, DecodeError) {
-    case decode_ex(toml_string) {
-      Ok(value) -> Ok(value)
-      Error(err) -> Error(InvalidTomlError(get_reason(err)))
-    }
+@target(erlang)
+fn decode_inner(toml_string: String) -> Result(dyn.Dynamic, DecodeError) {
+  case decode_ex(toml_string) {
+    Ok(value) -> Ok(value)
+    Error(err) -> Error(InvalidTomlError(get_reason(err)))
   }
 }
 
-if javascript {
-  external fn decode_js(toml_string: String) -> Result(dyn.Dynamic, String) =
-    "./toml_ffi.mjs" "parse_toml"
+@target(javascript)
+@external(javascript, "./toml_ffi.mjs", "parse_toml")
+fn decode_js(toml_string: String) -> Result(dyn.Dynamic, String)
 
-  fn decode_inner(toml_string: String) -> Result(dyn.Dynamic, DecodeError) {
-    decode_js(toml_string)
-    |> result.map_error(InvalidTomlError)
-  }
+@target(javascript)
+fn decode_inner(toml_string: String) -> Result(dyn.Dynamic, DecodeError) {
+  decode_js(toml_string)
+  |> result.map_error(InvalidTomlError)
 }


### PR DESCRIPTION
This PR updates the Gleam version to 0.31 and uses the new `external` syntax